### PR TITLE
Replace console.log with StreamReport

### DIFF
--- a/.yarn/plugins/@yarnpkg/plugin-echo-execute.cjs
+++ b/.yarn/plugins/@yarnpkg/plugin-echo-execute.cjs
@@ -2,7 +2,7 @@
 module.exports = {
 name: "@yarnpkg/plugin-echo-execute",
 factory: function (require) {
-var plugin;(()=>{"use strict";var e={d:(t,r)=>{for(var o in r)e.o(r,o)&&!e.o(t,o)&&Object.defineProperty(t,o,{enumerable:!0,get:r[o]})},o:(e,t)=>Object.prototype.hasOwnProperty.call(e,t),r:e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})}},t={};(()=>{e.r(t),e.d(t,{default:()=>r});const r={hooks:{wrapScriptExecution:async(e,t,r,o,n)=>()=>{const t=n.script.startsWith("yarn ")?n.script:"yarn "+n.script;return console.info(`${o}> ${t}`),e()}}}})(),plugin=t})();
+var plugin;(()=>{"use strict";var e={d:(o,t)=>{for(var r in t)e.o(t,r)&&!e.o(o,r)&&Object.defineProperty(o,r,{enumerable:!0,get:t[r]})},o:(e,o)=>Object.prototype.hasOwnProperty.call(e,o),r:e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})}},o={};e.r(o),e.d(o,{default:()=>r});const t=require("@yarnpkg/core"),r={hooks:{wrapScriptExecution:async(e,o,r,a,n)=>async()=>(await t.StreamReport.start({configuration:o.configuration,json:!1,includeFooter:!1,stdout:n.stdout},async e=>{e.reportInfo(t.MessageName.UNNAMED,t.formatUtils.applyColor(o.configuration,`[${a}] ${n.script}`,t.formatUtils.Type.NO_HINT))}),e())}};plugin=o})();
 return plugin;
 }
 };

--- a/bundles/@yarnpkg/plugin-echo-execute.js
+++ b/bundles/@yarnpkg/plugin-echo-execute.js
@@ -2,7 +2,7 @@
 module.exports = {
 name: "@yarnpkg/plugin-echo-execute",
 factory: function (require) {
-var plugin;(()=>{"use strict";var e={d:(t,r)=>{for(var o in r)e.o(r,o)&&!e.o(t,o)&&Object.defineProperty(t,o,{enumerable:!0,get:r[o]})},o:(e,t)=>Object.prototype.hasOwnProperty.call(e,t),r:e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})}},t={};(()=>{e.r(t),e.d(t,{default:()=>r});const r={hooks:{wrapScriptExecution:async(e,t,r,o,n)=>()=>{const t=n.script.startsWith("yarn ")?n.script:"yarn "+n.script;return console.info(`${o}> ${t}`),e()}}}})(),plugin=t})();
+var plugin;(()=>{"use strict";var e={d:(o,t)=>{for(var r in t)e.o(t,r)&&!e.o(o,r)&&Object.defineProperty(o,r,{enumerable:!0,get:t[r]})},o:(e,o)=>Object.prototype.hasOwnProperty.call(e,o),r:e=>{"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(e,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(e,"__esModule",{value:!0})}},o={};e.r(o),e.d(o,{default:()=>r});const t=require("@yarnpkg/core"),r={hooks:{wrapScriptExecution:async(e,o,r,a,n)=>async()=>(await t.StreamReport.start({configuration:o.configuration,json:!1,includeFooter:!1,stdout:n.stdout},async e=>{e.reportInfo(t.MessageName.UNNAMED,t.formatUtils.applyColor(o.configuration,`[${a}] ${n.script}`,t.formatUtils.Type.NO_HINT))}),e())}};plugin=o})();
 return plugin;
 }
 };


### PR DESCRIPTION
## Premise
Hello, there. I've found your plugin while going through the discussion in https://github.com/yarnpkg/berry/issues/1215.
First of all, thanks for jumping on it and building a practical solution! After getting used to the slight verbosity of Yarn v1, the new behaviour is indeed annoying.

## Rationale
I started using your plugin, but seeing its plain logs interspersed with Yarn's own made them feel a bit out of place. So I tried to see whether there was a way to hook into Yarn's logging (I'm quite new to Yarn itself), and this is the result.

## Changes
- Replace `console.log` with `[StreamReport instance].reportInfo`
- Remove prefix when command does not start with `yarn`

About the second change—I'm not sure why you added it, but if it was to make the log easier to identify, possibly the new appearance should solve this already? let me know.

Thanks again for giving me a starting point.

## New appearance
From:

```
test> yarn eslint .
```

..to:

```
➤ YN0000: [test] eslint .
```
